### PR TITLE
Add a primitive slide in menu, controlling a global tabbarcontroller

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -18,45 +18,45 @@ PODS:
     - FacebookCore (~> 0.3)
     - FBSDKCoreKit (~> 4.27)
     - FBSDKShareKit (~> 4.27)
-  - FBSDKCoreKit (4.31.1):
+  - FBSDKCoreKit (4.30.0):
     - Bolts (~> 1.7)
-  - FBSDKLoginKit (4.31.1):
+  - FBSDKLoginKit (4.30.0):
     - FBSDKCoreKit
-  - FBSDKShareKit (4.31.1):
-    - FBSDKCoreKit (~> 4.31.1)
-  - Firebase (4.10.1):
-    - Firebase/Core (= 4.10.1)
-  - Firebase/Auth (4.10.1):
+  - FBSDKShareKit (4.30.0):
+    - FBSDKCoreKit (~> 4.30.0)
+  - Firebase (4.9.0):
+    - Firebase/Core (= 4.9.0)
+  - Firebase/Auth (4.9.0):
     - Firebase/Core
-    - FirebaseAuth (= 4.4.4)
-  - Firebase/Core (4.10.1):
-    - FirebaseAnalytics (= 4.1.0)
-    - FirebaseCore (= 4.0.17)
-  - Firebase/Database (4.10.1):
+    - FirebaseAuth (= 4.4.3)
+  - Firebase/Core (4.9.0):
+    - FirebaseAnalytics (= 4.0.9)
+    - FirebaseCore (= 4.0.15)
+  - Firebase/Database (4.9.0):
     - Firebase/Core
-    - FirebaseDatabase (= 4.1.5)
-  - Firebase/Storage (4.10.1):
+    - FirebaseDatabase (= 4.1.4)
+  - Firebase/Storage (4.9.0):
     - Firebase/Core
-    - FirebaseStorage (= 2.1.3)
-  - FirebaseAnalytics (4.1.0):
+    - FirebaseStorage (= 2.1.2)
+  - FirebaseAnalytics (4.0.9):
     - FirebaseCore (~> 4.0)
     - FirebaseInstanceID (~> 2.0)
     - GoogleToolboxForMac/NSData+zlib (~> 2.1)
     - nanopb (~> 0.3)
-  - FirebaseAuth (4.4.4):
-    - FirebaseAnalytics (~> 4.1)
+  - FirebaseAuth (4.4.3):
+    - FirebaseAnalytics (~> 4.0)
     - GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)
     - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseCore (4.0.17):
+  - FirebaseCore (4.0.15):
     - GoogleToolboxForMac/NSData+zlib (~> 2.1)
-  - FirebaseDatabase (4.1.5):
-    - FirebaseAnalytics (~> 4.1)
+  - FirebaseDatabase (4.1.4):
+    - FirebaseAnalytics (~> 4.0)
     - FirebaseCore (~> 4.0)
     - leveldb-library (~> 1.18)
   - FirebaseInstanceID (2.0.9):
     - FirebaseCore (~> 4.0)
-  - FirebaseStorage (2.1.3):
-    - FirebaseAnalytics (~> 4.1)
+  - FirebaseStorage (2.1.2):
+    - FirebaseAnalytics (~> 4.0)
     - FirebaseCore (~> 4.0)
     - GTMSessionFetcher/Core (~> 1.1)
   - GoogleMaps (2.6.0):
@@ -75,7 +75,7 @@ PODS:
     - GoogleToolboxForMac/NSString+URLArguments (= 2.1.3)
   - GoogleToolboxForMac/NSString+URLArguments (2.1.3)
   - GTMSessionFetcher/Core (1.1.13)
-  - Kingfisher (4.6.3)
+  - Kingfisher (4.6.2)
   - leveldb-library (1.20)
   - nanopb (0.3.8):
     - nanopb/decode (= 0.3.8)
@@ -105,21 +105,20 @@ SPEC CHECKSUMS:
   FacebookCore: 3ffa190a3f1f96cec0e44d3fc221bc322c595ffa
   FacebookLogin: 0af839ea858faef99550d16596b87b4a8e8906e6
   FacebookShare: 0469964297ebd75f052be2c5083389a4208e82b7
-  FBSDKCoreKit: e08ccfcefa7bc1347a07c276dac9bf6c7fe57024
-  FBSDKLoginKit: 99797ac39252fef6f72600b886f6ee60b4b29cab
-  FBSDKShareKit: e640c41c9fcd61929eeb3d0c21ad335103e7cb62
-  Firebase: 92c6ba593e32db0defde464a9adc981d5cb49f97
-  FirebaseAnalytics: 3dfae28d4a5e06f86c4fae830efc2ad3fadb19bc
-  FirebaseAuth: d040bb7a9db6dfc29d0e7ec82d48be51352b2581
-  FirebaseCore: 872307b001bbefda1dfa0dbfffa50a6919023d4a
-  FirebaseDatabase: 5f0bc6134c5c237cf55f9e1249d406770a75eafd
+  FBSDKCoreKit: 7c4bba2877781a131ab5d54c0a78c405d4307b62
+  FBSDKLoginKit: fe7a7e82373dc5daad92e1623219e86224ab1fb1
+  FBSDKShareKit: a9427574b51bde4f437262c3f118c4ccfddeef6c
+  Firebase: 632216af3ed7f31e3be34776947fdc7546cfb572
+  FirebaseAnalytics: 388b630c15713f5dbf364071f5f3d6077fb52f4e
+  FirebaseAuth: aaaf68d5064a6c8fec435758f83a43b8db26ccaa
+  FirebaseCore: 3bd047463058fa6b5d312c97502c52e45401cdfb
+  FirebaseDatabase: de4446507ccd3257fca37d16f40e1540324571fd
   FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
-  FirebaseStorage: 9a863a2bb96c406958eeff7c2f1dfa9f44c44a13
+  FirebaseStorage: 181bb543d39ee3c53e0558de7ba86b1286a0427f
   GoogleMaps: 42f91c68b7fa2f84d5c86597b18ceb99f5414c7f
   GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
   GTMSessionFetcher: 5bb1eae636127de695590f50e7d248483eb891e6
-  Kingfisher: 98e6d5b5e807645743e8ed5ececd25d688d38452
-
+  Kingfisher: 55b9c395bf8d3949676ad3861111923990ab68cf
   leveldb-library: 08cba283675b7ed2d99629a4bc5fd052cd2bb6a5
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
   SnapKit: a42d492c16e80209130a3379f73596c3454b7694

--- a/wmsy.xcodeproj/project.pbxproj
+++ b/wmsy.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		811FFB5720606B5500F3312B /* CollapsedFeedCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811FFB5620606B5500F3312B /* CollapsedFeedCellView.swift */; };
 		8139A99D205C2E9F006C7058 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8139A99C205C2E9F006C7058 /* GoogleService-Info.plist */; };
 		8139A99F205C309F006C7058 /* Whim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8139A99E205C309F006C7058 /* Whim.swift */; };
 		8139A9A2205C30D7006C7058 /* CreateWhimTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8139A9A1205C30D7006C7058 /* CreateWhimTVC.swift */; };
@@ -36,7 +37,7 @@
 		81BAD691205AEF6600C7F039 /* SideMenuVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BAD690205AEF6600C7F039 /* SideMenuVC.swift */; };
 		81BAD693205AEF7B00C7F039 /* MyChatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BAD692205AEF7B00C7F039 /* MyChatsView.swift */; };
 		81BAD695205AEF8900C7F039 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BAD694205AEF8900C7F039 /* ProfileView.swift */; };
-		81BAD69B205AF03600C7F039 /* ChatRoomTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BAD69A205AF03600C7F039 /* ChatRoomTVC.swift */; };
+		81BAD69B205AF03600C7F039 /* ChatRoomVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BAD69A205AF03600C7F039 /* ChatRoomVC.swift */; };
 		81BAD69D205AF04600C7F039 /* HostChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BAD69C205AF04600C7F039 /* HostChatView.swift */; };
 		81BAD69F205AF05500C7F039 /* GuestChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BAD69E205AF05500C7F039 /* GuestChatView.swift */; };
 		81BAD6A1205AF06900C7F039 /* HostMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BAD6A0205AF06900C7F039 /* HostMessageCell.swift */; };
@@ -44,12 +45,24 @@
 		81BAD6A5205AF08100C7F039 /* NotificationMsgCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BAD6A4205AF08100C7F039 /* NotificationMsgCell.swift */; };
 		81BAD6A7205AF09400C7F039 /* LocationDetailsMsgCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BAD6A6205AF09400C7F039 /* LocationDetailsMsgCell.swift */; };
 		81BAD6A9205AF0AA00C7F039 /* GuestProfileVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BAD6A8205AF0AA00C7F039 /* GuestProfileVC.swift */; };
+		81DECD19205C87ED00214866 /* MenuedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD18205C87ED00214866 /* MenuedViewController.swift */; };
+		81DECD1B205C87FA00214866 /* Interactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD1A205C87FA00214866 /* Interactor.swift */; };
+		81DECD1D205C881200214866 /* MenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD1C205C881200214866 /* MenuHelper.swift */; };
+		81DECD1F205C882100214866 /* PresentMenuAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD1E205C882100214866 /* PresentMenuAnimator.swift */; };
+		81DECD21205C882900214866 /* DismissMenuAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD20205C882900214866 /* DismissMenuAnimator.swift */; };
+		81DECD23205C892B00214866 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD22205C892B00214866 /* MenuViewController.swift */; };
+		81DECD26205C91F900214866 /* MenuProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD25205C91F900214866 /* MenuProfileView.swift */; };
+		81DECD28205C932200214866 /* MenuWhimsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD27205C932200214866 /* MenuWhimsView.swift */; };
+		81DECD2A205C93A300214866 /* MenuCollectionViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD29205C93A300214866 /* MenuCollectionViewWrapper.swift */; };
+		81DECD2C205DECF900214866 /* MenuWhimsHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD2B205DECF900214866 /* MenuWhimsHeader.swift */; };
+		81DECD2E205E229E00214866 /* MenuWhimsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD2D205E229E00214866 /* MenuWhimsCell.swift */; };
+		81DECD3020600C8900214866 /* MainTabBarVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD2F20600C8900214866 /* MainTabBarVC.swift */; };
+		81DECD3220600FB000214866 /* Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DECD3120600FB000214866 /* Page.swift */; };
 		81EBB5892060117D008A6CE7 /* StorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81EBB5882060117D008A6CE7 /* StorageService.swift */; };
 		81EBB58B20601939008A6CE7 /* StorageService+Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81EBB58A20601939008A6CE7 /* StorageService+Image.swift */; };
 		81EBB58D20601C7E008A6CE7 /* DBService+AppUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81EBB58C20601C7E008A6CE7 /* DBService+AppUser.swift */; };
 		81EBB58F20601C86008A6CE7 /* DBService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81EBB58E20601C86008A6CE7 /* DBService.swift */; };
 		8449A2DA7A870D7DFE6E2428 /* Pods_wmsy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CEEC5ACCA9E78DD3C3881CA /* Pods_wmsy.framework */; };
-		93495B0420603F8E0080BDBA /* CollapsedFeedCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93495B0320603F8E0080BDBA /* CollapsedFeedCellView.swift */; };
 		93495B0620603F9A0080BDBA /* ExpandedFeedCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93495B0520603F9A0080BDBA /* ExpandedFeedCellView.swift */; };
 		93495B08206041080080BDBA /* FeedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93495B07206041080080BDBA /* FeedCell.swift */; };
 		E5E0CC0CB13ED0D202D6CA35 /* Pods_wmsyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7ABB5CDA9ED0EA6DABA10A94 /* Pods_wmsyTests.framework */; };
@@ -70,6 +83,7 @@
 		12481557B949A7967EAD55F0 /* Pods-wmsyTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-wmsyTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-wmsyTests/Pods-wmsyTests.release.xcconfig"; sourceTree = "<group>"; };
 		7ABB5CDA9ED0EA6DABA10A94 /* Pods_wmsyTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_wmsyTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7CEEC5ACCA9E78DD3C3881CA /* Pods_wmsy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_wmsy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		811FFB5620606B5500F3312B /* CollapsedFeedCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsedFeedCellView.swift; sourceTree = "<group>"; };
 		8139A99C205C2E9F006C7058 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8139A99E205C309F006C7058 /* Whim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Whim.swift; sourceTree = "<group>"; };
 		8139A9A1205C30D7006C7058 /* CreateWhimTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateWhimTVC.swift; sourceTree = "<group>"; };
@@ -103,7 +117,7 @@
 		81BAD690205AEF6600C7F039 /* SideMenuVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuVC.swift; sourceTree = "<group>"; };
 		81BAD692205AEF7B00C7F039 /* MyChatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyChatsView.swift; sourceTree = "<group>"; };
 		81BAD694205AEF8900C7F039 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
-		81BAD69A205AF03600C7F039 /* ChatRoomTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomTVC.swift; sourceTree = "<group>"; };
+		81BAD69A205AF03600C7F039 /* ChatRoomVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomVC.swift; sourceTree = "<group>"; };
 		81BAD69C205AF04600C7F039 /* HostChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostChatView.swift; sourceTree = "<group>"; };
 		81BAD69E205AF05500C7F039 /* GuestChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestChatView.swift; sourceTree = "<group>"; };
 		81BAD6A0205AF06900C7F039 /* HostMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostMessageCell.swift; sourceTree = "<group>"; };
@@ -111,12 +125,24 @@
 		81BAD6A4205AF08100C7F039 /* NotificationMsgCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationMsgCell.swift; sourceTree = "<group>"; };
 		81BAD6A6205AF09400C7F039 /* LocationDetailsMsgCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDetailsMsgCell.swift; sourceTree = "<group>"; };
 		81BAD6A8205AF0AA00C7F039 /* GuestProfileVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestProfileVC.swift; sourceTree = "<group>"; };
+		81DECD18205C87ED00214866 /* MenuedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuedViewController.swift; sourceTree = "<group>"; };
+		81DECD1A205C87FA00214866 /* Interactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interactor.swift; sourceTree = "<group>"; };
+		81DECD1C205C881200214866 /* MenuHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuHelper.swift; sourceTree = "<group>"; };
+		81DECD1E205C882100214866 /* PresentMenuAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentMenuAnimator.swift; sourceTree = "<group>"; };
+		81DECD20205C882900214866 /* DismissMenuAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissMenuAnimator.swift; sourceTree = "<group>"; };
+		81DECD22205C892B00214866 /* MenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
+		81DECD25205C91F900214866 /* MenuProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuProfileView.swift; sourceTree = "<group>"; };
+		81DECD27205C932200214866 /* MenuWhimsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuWhimsView.swift; sourceTree = "<group>"; };
+		81DECD29205C93A300214866 /* MenuCollectionViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCollectionViewWrapper.swift; sourceTree = "<group>"; };
+		81DECD2B205DECF900214866 /* MenuWhimsHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuWhimsHeader.swift; sourceTree = "<group>"; };
+		81DECD2D205E229E00214866 /* MenuWhimsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuWhimsCell.swift; sourceTree = "<group>"; };
+		81DECD2F20600C8900214866 /* MainTabBarVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarVC.swift; sourceTree = "<group>"; };
+		81DECD3120600FB000214866 /* Page.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Page.swift; sourceTree = "<group>"; };
 		81EBB5882060117D008A6CE7 /* StorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageService.swift; sourceTree = "<group>"; };
 		81EBB58A20601939008A6CE7 /* StorageService+Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageService+Image.swift"; sourceTree = "<group>"; };
 		81EBB58C20601C7E008A6CE7 /* DBService+AppUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DBService+AppUser.swift"; sourceTree = "<group>"; };
 		81EBB58E20601C86008A6CE7 /* DBService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBService.swift; sourceTree = "<group>"; };
 		876DF1E5D004E38FACE607E8 /* Pods-wmsy.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-wmsy.release.xcconfig"; path = "Pods/Target Support Files/Pods-wmsy/Pods-wmsy.release.xcconfig"; sourceTree = "<group>"; };
-		93495B0320603F8E0080BDBA /* CollapsedFeedCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsedFeedCellView.swift; sourceTree = "<group>"; };
 		93495B0520603F9A0080BDBA /* ExpandedFeedCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandedFeedCellView.swift; sourceTree = "<group>"; };
 		93495B07206041080080BDBA /* FeedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCell.swift; sourceTree = "<group>"; };
 		A3CBD7D0321B7C36EB143EB4 /* Pods-wmsy.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-wmsy.debug.xcconfig"; path = "Pods/Target Support Files/Pods-wmsy/Pods-wmsy.debug.xcconfig"; sourceTree = "<group>"; };
@@ -248,7 +274,7 @@
 				81BAD67A205AEDAA00C7F039 /* FeedMapVC.swift */,
 				81BAD67C205AEDBF00C7F039 /* FeedView.swift */,
 				81BAD67E205AEDC800C7F039 /* MapView.swift */,
-				93495B0320603F8E0080BDBA /* CollapsedFeedCellView.swift */,
+				811FFB5620606B5500F3312B /* CollapsedFeedCellView.swift */,
 				93495B0520603F9A0080BDBA /* ExpandedFeedCellView.swift */,
 				93495B07206041080080BDBA /* FeedCell.swift */,
 			);
@@ -258,6 +284,8 @@
 		81BAD682205AEDE800C7F039 /* SideMenuPage */ = {
 			isa = PBXGroup;
 			children = (
+				81DECD17205C878E00214866 /* SupportFiles */,
+				81DECD24205C910100214866 /* Views */,
 				81BAD690205AEF6600C7F039 /* SideMenuVC.swift */,
 				81BAD692205AEF7B00C7F039 /* MyChatsView.swift */,
 				81BAD694205AEF8900C7F039 /* ProfileView.swift */,
@@ -268,7 +296,7 @@
 		81BAD684205AEE1500C7F039 /* ChatRoomPage */ = {
 			isa = PBXGroup;
 			children = (
-				81BAD69A205AF03600C7F039 /* ChatRoomTVC.swift */,
+				81BAD69A205AF03600C7F039 /* ChatRoomVC.swift */,
 				81BAD69C205AF04600C7F039 /* HostChatView.swift */,
 				81BAD69E205AF05500C7F039 /* GuestChatView.swift */,
 				81BAD6A0205AF06900C7F039 /* HostMessageCell.swift */,
@@ -309,6 +337,33 @@
 				81EBB58E20601C86008A6CE7 /* DBService.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		81DECD17205C878E00214866 /* SupportFiles */ = {
+			isa = PBXGroup;
+			children = (
+				81DECD22205C892B00214866 /* MenuViewController.swift */,
+				81DECD18205C87ED00214866 /* MenuedViewController.swift */,
+				81DECD2F20600C8900214866 /* MainTabBarVC.swift */,
+				81DECD3120600FB000214866 /* Page.swift */,
+				81DECD1A205C87FA00214866 /* Interactor.swift */,
+				81DECD1C205C881200214866 /* MenuHelper.swift */,
+				81DECD1E205C882100214866 /* PresentMenuAnimator.swift */,
+				81DECD20205C882900214866 /* DismissMenuAnimator.swift */,
+			);
+			path = SupportFiles;
+			sourceTree = "<group>";
+		};
+		81DECD24205C910100214866 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				81DECD25205C91F900214866 /* MenuProfileView.swift */,
+				81DECD27205C932200214866 /* MenuWhimsView.swift */,
+				81DECD2B205DECF900214866 /* MenuWhimsHeader.swift */,
+				81DECD2D205E229E00214866 /* MenuWhimsCell.swift */,
+				81DECD29205C93A300214866 /* MenuCollectionViewWrapper.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		B2F8ADA7007772FA5D9A5CEF /* Pods */ = {
@@ -567,7 +622,9 @@
 			files = (
 				81EBB58D20601C7E008A6CE7 /* DBService+AppUser.swift in Sources */,
 				81BAD6A3205AF07300C7F039 /* GuestMessageCell.swift in Sources */,
+				81DECD2A205C93A300214866 /* MenuCollectionViewWrapper.swift in Sources */,
 				81BAD67F205AEDC800C7F039 /* MapView.swift in Sources */,
+				81DECD2E205E229E00214866 /* MenuWhimsCell.swift in Sources */,
 				81AB7AC0205C806C009845EA /* WhimLocationTableViewCell.swift in Sources */,
 				81AB7ABA205C800E009845EA /* WhimTitleTableViewCell.swift in Sources */,
 				81EBB58F20601C86008A6CE7 /* DBService.swift in Sources */,
@@ -578,29 +635,40 @@
 				81AB7AC6205C94DD009845EA /* WhimCategoryCollectionViewCell.swift in Sources */,
 				93495B08206041080080BDBA /* FeedCell.swift in Sources */,
 				81AB7ABC205C8024009845EA /* WhimDescriptionTableViewCell.swift in Sources */,
+				81DECD21205C882900214866 /* DismissMenuAnimator.swift in Sources */,
+				81DECD23205C892B00214866 /* MenuViewController.swift in Sources */,
 				81BAD69D205AF04600C7F039 /* HostChatView.swift in Sources */,
 				81BAD6A5205AF08100C7F039 /* NotificationMsgCell.swift in Sources */,
 				8139A9A2205C30D7006C7058 /* CreateWhimTVC.swift in Sources */,
+				81DECD2C205DECF900214866 /* MenuWhimsHeader.swift in Sources */,
 				81903105205ADCF200932A55 /* AppDelegate.swift in Sources */,
 				81BAD678205AED7100C7F039 /* LoginView.swift in Sources */,
 				93495B0620603F9A0080BDBA /* ExpandedFeedCellView.swift in Sources */,
 				81AB7AC8205C9548009845EA /* Stylesheet.swift in Sources */,
+				81DECD1B205C87FA00214866 /* Interactor.swift in Sources */,
+				81DECD26205C91F900214866 /* MenuProfileView.swift in Sources */,
+				81DECD19205C87ED00214866 /* MenuedViewController.swift in Sources */,
 				81BAD69F205AF05500C7F039 /* GuestChatView.swift in Sources */,
 				81AB7AC2205C80B4009845EA /* WhimCategoryTableViewCell.swift in Sources */,
 				81EBB5892060117D008A6CE7 /* StorageService.swift in Sources */,
 				81BAD6A7205AF09400C7F039 /* LocationDetailsMsgCell.swift in Sources */,
 				81AB7ACB205CA256009845EA /* Categories.swift in Sources */,
 				81BAD695205AEF8900C7F039 /* ProfileView.swift in Sources */,
+				81DECD28205C932200214866 /* MenuWhimsView.swift in Sources */,
+				81DECD3020600C8900214866 /* MainTabBarVC.swift in Sources */,
+				81DECD1F205C882100214866 /* PresentMenuAnimator.swift in Sources */,
 				81BAD676205AED5D00C7F039 /* LoginVC.swift in Sources */,
 				8139A99F205C309F006C7058 /* Whim.swift in Sources */,
 				81BAD691205AEF6600C7F039 /* SideMenuVC.swift in Sources */,
+				81DECD1D205C881200214866 /* MenuHelper.swift in Sources */,
 				81BAD67D205AEDBF00C7F039 /* FeedView.swift in Sources */,
 				8139A9A6205C3130006C7058 /* CreateWhimView.swift in Sources */,
-				81BAD69B205AF03600C7F039 /* ChatRoomTVC.swift in Sources */,
+				81BAD69B205AF03600C7F039 /* ChatRoomVC.swift in Sources */,
 				81EBB58B20601939008A6CE7 /* StorageService+Image.swift in Sources */,
 				81BAD68F205AEEE200C7F039 /* Message.swift in Sources */,
 				81BAD67B205AEDAA00C7F039 /* FeedMapVC.swift in Sources */,
-				93495B0420603F8E0080BDBA /* CollapsedFeedCellView.swift in Sources */,
+				81DECD3220600FB000214866 /* Page.swift in Sources */,
+				811FFB5720606B5500F3312B /* CollapsedFeedCellView.swift in Sources */,
 				81AB7ABE205C805A009845EA /* WhimExpirationTableViewCell.swift in Sources */,
 				81BAD6A9205AF0AA00C7F039 /* GuestProfileVC.swift in Sources */,
 				81BAD68B205AEEC900C7F039 /* Interest.swift in Sources */,

--- a/wmsy/AppDelegate.swift
+++ b/wmsy/AppDelegate.swift
@@ -22,18 +22,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
         SDKApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
-        if AccessToken.current != nil{
-            let vc = FeedMapVC()
-            let nav = UINavigationController(rootViewController: vc)
-            window = UIWindow(frame: UIScreen.main.bounds)
-            window?.rootViewController = nav
-            window?.makeKeyAndVisible()
-        }else{
-        let vc = LoginVC()
+//        if AccessToken.current != nil{
+//            let vc = FeedMapVC()
+//            let nav = UINavigationController(rootViewController: vc)
+//            window = UIWindow(frame: UIScreen.main.bounds)
+//            window?.rootViewController = nav
+//            window?.makeKeyAndVisible()
+//        }else{
+//        let vc = LoginVC()
+        let vc = MainTabBarVC()
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = vc
         window?.makeKeyAndVisible()
-        }
+//        }
         return true
     }
 

--- a/wmsy/Pages/ChatRoomPage/ChatRoomVC.swift
+++ b/wmsy/Pages/ChatRoomPage/ChatRoomVC.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ChatRoomTVC: UITableViewController {
+class ChatRoomVC: MenuedViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,15 +27,15 @@ class ChatRoomTVC: UITableViewController {
 
     // MARK: - Table view data source
 
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
-        return 0
-    }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
-        return 0
-    }
+//    override func numberOfSections(in tableView: UITableView) -> Int {
+//        // #warning Incomplete implementation, return the number of sections
+//        return 0
+//    }
+//
+//    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+//        // #warning Incomplete implementation, return the number of rows
+//        return 0
+//    }
 
     /*
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/wmsy/Pages/ChatRoomPage/NotificationMsgCell.swift
+++ b/wmsy/Pages/ChatRoomPage/NotificationMsgCell.swift
@@ -17,7 +17,6 @@ class NotificationMsgCell: UITableViewCell {
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
         // Configure the view for the selected state
     }
 

--- a/wmsy/Pages/FeedMapPage/CollapsedFeedCellView.swift
+++ b/wmsy/Pages/FeedMapPage/CollapsedFeedCellView.swift
@@ -70,3 +70,4 @@ class CollapsedFeedCellView: UIView {
     }
     
 }
+

--- a/wmsy/Pages/FeedMapPage/FeedMapVC.swift
+++ b/wmsy/Pages/FeedMapPage/FeedMapVC.swift
@@ -7,8 +7,9 @@
 //
 
 import UIKit
+import SnapKit
 
-class FeedMapVC: UIViewController {
+class FeedMapVC: MenuedViewController {
     
     var feedView = FeedView()
     var expandedRows = Set<Int>()
@@ -16,12 +17,15 @@ class FeedMapVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.addSubview(feedView)
+        feedView.snp.makeConstraints { (make) in
+            make.edges.equalTo(view.safeAreaLayoutGuide)
+        }
         feedView.tableView.register(FeedCell.self, forCellReuseIdentifier: "WhimFeedCell")
         feedView.tableView.dataSource = self
         feedView.tableView.delegate = self
         feedView.tableView.rowHeight = UITableViewAutomaticDimension
         feedView.tableView.estimatedRowHeight = 90
-        configureNavBar()
+//        configureNavBar()
     }
     
     

--- a/wmsy/Pages/LoginPage/LoginVC.swift
+++ b/wmsy/Pages/LoginPage/LoginVC.swift
@@ -86,9 +86,10 @@ extension LoginVC: loginViewDelegate {
                                 let newUser = AppUser(name: userName!, photoID: "", age: "", userID: userID!, bio: "", badge: false, flags: 0)
                                 DBService.manager.addAppUser(newUser, image: image!)
                             })
-                            let vc = FeedMapVC()
-                            let nav = UINavigationController(rootViewController: vc)
-                            self.present(nav, animated: true, completion: nil)
+                            (self.tabBarController as? MainTabBarVC)?.animateTo(page: .feedAndMap, fromViewController: self)
+//                            let vc = FeedMapVC()
+//                            let nav = UINavigationController(rootViewController: vc)
+//                            self.present(nav, animated: true, completion: nil)
                         })
                     case .failed(let error):
                         print("Custom Graph Request Failed: \(error)")

--- a/wmsy/Pages/SideMenuPage/SideMenuVC.swift
+++ b/wmsy/Pages/SideMenuPage/SideMenuVC.swift
@@ -7,29 +7,158 @@
 //
 
 import UIKit
+import SnapKit
 
-class SideMenuVC: UIViewController {
 
+class SideMenuVC: MenuViewController {
+//    var viewIsVisible: Bool = true
+//    override var prefersStatusBarHidden: Bool {
+//        return !viewIsVisible
+//    }
+    var newMenu: MenuCollectionViewWrapper!
     override func viewDidLoad() {
         super.viewDidLoad()
-
+//        self.automaticallyAdjustsScrollViewInsets = false
+        newMenu = MenuCollectionViewWrapper(frame: menuScreen.frame)
+        newMenu.menuPagesCollectionView.dataSource = self
+        newMenu.menuPagesCollectionView.delegate = self
+//        newMenu.backgroundColor = Stylesheet.Colors.WMSYMummysTomb
+        menuScreen.addSubview(newMenu)
+        newMenu.snp.makeConstraints { (make) in
+            make.edges.equalTo(menuScreen)
+        }
+//        newMenu = MenuCollectionViewWrapper(frame: view.frame)
+//        view.insertSubview(newMenu, belowSubview: snapShotOfMenuedViewController)
+//        view.bringSubview(toFront: snapShotOfMenuedViewController)
         // Do any additional setup after loading the view.
     }
-
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+    
+//    override func viewDidLayoutSubviews() {
+//        super.viewDidLayoutSubviews()
+//        print(newMenu.bounds.height)
+//        newMenu.layoutStuff()
+//    }
+//    override func viewWillLayoutSubviews() {
+//        super.viewWillLayoutSubviews()
+//        print(newMenu.bounds.height)
+//    }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+//        viewIsVisible = true
+//        UIView.animate(withDuration: 0.5) {
+//            self.setNeedsStatusBarAppearanceUpdate()
+//        }
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destinationViewController.
-        // Pass the selected object to the new view controller.
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+//        self.viewIsVisible = true
+//        UIView.animate(withDuration: 0.1) {
+//            self.setNeedsStatusBarAppearanceUpdate()
+//        }
+//        navigationController.set
+//        super.viewDidAppear(animated)
+//        print(newMenu.bounds.height)
+//        newMenu.layoutStuff()
     }
-    */
-
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+//        viewIsVisible = false
+//        prefersStatusBarHidden = false
+    }
+    private var lastContentOffset: CGFloat = 0
 }
+
+extension SideMenuVC: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 0
+    }
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 2
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        switch indexPath.item {
+        case 0:
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MenuCollectionViewWrapper.pageOneIdentifier, for: indexPath) as! MenuProfileView
+            cell.signOutButton.addTarget(self, action: #selector(signOut), for: .touchUpInside)
+            cell.signOutButton.addTarget(self, action: #selector(signOut), for: .touchUpInside)
+            cell.signOutButton.addTarget(self, action: #selector(signOut), for: .touchUpInside)
+            return cell
+        case 1:
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MenuCollectionViewWrapper.pageTwoIdentifier, for: indexPath) as! MenuWhimsView
+            cell.whimsTableView.dataSource = self
+            cell.whimsTableView.delegate = self
+            return cell
+        default:
+            return UICollectionViewCell()
+        }
+    }
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return menuScreen.bounds.size
+    }
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if (self.lastContentOffset > scrollView.contentOffset.y) {
+            // move up
+        }
+        else if (self.lastContentOffset < scrollView.contentOffset.y) {
+            // move down
+        }
+    }
+    
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+//        let targetContentOffset = scrollView.contentOffset
+////        float pageWidth = (float)self.articlesCollectionView.bounds.size.width;
+//        let pageWidth = newMenu.menuPagesCollectionView.bounds.size.width
+////        int minSpace = 10;
+//        let minSpace: CGFloat = 10
+////
+////        int cellToSwipe = (scrollView.contentOffset.x)/(pageWidth + minSpace) + 0.5; // cell width + min spacing for lines
+//        var cellToSwipe = (scrollView.contentOffset.x) / (pageWidth + minSpace) + 0.5
+////        if (cellToSwipe < 0) {
+////            cellToSwipe = 0;
+////        } else if (cellToSwipe >= self.articles.count) {
+////            cellToSwipe = self.articles.count - 1;
+////        }
+//        if cellToSwipe < 0 {
+//            cellToSwipe = 0
+//        } else if cellToSwipe >= 2 { // should represent datasource.count
+//            cellToSwipe = 1 // should be last index of datasource
+//        }
+//        newMenu.menuPagesCollectionView.scrollToItem(at: IndexPath.init(row: Int(cellToSwipe), section: 0), at: .left, animated: true)
+////        [self.articlesCollectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForRow:cellToSwipe inSection:0] atScrollPosition:UICollectionViewScrollPositionLeft animated:YES];
+    }
+}
+
+extension SideMenuVC: UITableViewDataSource, UITableViewDelegate {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 2 // Hosts and Guest Chats
+    }
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: MenuWhimsView.headerIdentifier) as! MenuWhimsHeader
+        return header
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 100
+        
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch indexPath.row {
+        case 0..<100:
+            let cell = tableView.dequeueReusableCell(withIdentifier: MenuWhimsView.cellIdentifier, for: indexPath)
+            return cell
+        default:
+            return UITableViewCell()
+        }
+        
+        
+        return UITableViewCell()
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
+    }
+}
+

--- a/wmsy/Pages/SideMenuPage/SupportFiles/DismissMenuAnimator.swift
+++ b/wmsy/Pages/SideMenuPage/SupportFiles/DismissMenuAnimator.swift
@@ -1,0 +1,48 @@
+//
+//  DismissMenuAnimator.swift
+//  wmsy
+//
+//  Created by C4Q on 3/16/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import UIKit
+
+class DismissMenuAnimator : NSObject {
+}
+
+extension DismissMenuAnimator : UIViewControllerAnimatedTransitioning {
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        return 0.6
+    }
+    
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        guard
+            let fromVC = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.from),
+            let toVC = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.to)
+            else {
+                return
+        }
+        let containerView = transitionContext.containerView
+        // 1
+        guard let snapshot = containerView.viewWithTag(MenuHelper.snapshotNumber) else { return }
+        
+        UIView.animate(
+            withDuration: transitionDuration(using: transitionContext),
+            animations: {
+                // 2
+                snapshot.frame = CGRect(origin: CGPoint.zero, size: UIScreen.main.bounds.size)
+        },
+            completion: { _ in
+                let didTransitionComplete = !transitionContext.transitionWasCancelled
+                if didTransitionComplete {
+                    // 3
+                    containerView.insertSubview(toVC.view, aboveSubview: fromVC.view)
+                    snapshot.removeFromSuperview()
+                }
+                transitionContext.completeTransition(didTransitionComplete)
+        }
+        )
+    }
+}
+

--- a/wmsy/Pages/SideMenuPage/SupportFiles/Interactor.swift
+++ b/wmsy/Pages/SideMenuPage/SupportFiles/Interactor.swift
@@ -1,0 +1,16 @@
+//
+//  Interactor.swift
+//  wmsy
+//
+//  Created by C4Q on 3/16/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+
+import UIKit
+
+class Interactor: UIPercentDrivenInteractiveTransition {
+    var hasStarted = false
+    var shouldFinish = false
+}
+

--- a/wmsy/Pages/SideMenuPage/SupportFiles/MainTabBarVC.swift
+++ b/wmsy/Pages/SideMenuPage/SupportFiles/MainTabBarVC.swift
@@ -1,0 +1,160 @@
+//
+//  MainTabBarVC.swift
+//  wmsy
+//
+//  Created by C4Q on 3/19/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import UIKit
+
+class MainTabBarVC: UITabBarController {
+    
+    let loginVC     = LoginVC()
+    let feedMapVC   = UINavigationController.init(rootViewController: FeedMapVC())
+    let chatRoomVC  = ChatRoomVC()
+    
+    
+//    let createVC    = CreateAccountViewController()
+//    let homeVC      = UINavigationController(rootViewController: HomeViewController())
+//    let decksVC     = UINavigationController(rootViewController: DecksViewController())
+//    let progressVC  = ProgressViewController()
+//    let browseVC    = BrowseViewController()
+//    let profileVC   = ProfileViewController()
+//    let inboxVC     = InboxViewController()
+    
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        loginVC.tabBarItem  = UITabBarItem(title: "login", image: nil, tag: 0)
+        feedMapVC.tabBarItem = UITabBarItem(title: "feed", image: nil, tag: 1)
+        chatRoomVC.tabBarItem = UITabBarItem(title: "chat room", image: nil, tag: 2)
+        
+        let controllers: [UIViewController] = [loginVC, feedMapVC, chatRoomVC]
+        
+        // comment to test with tab bar
+        self.tabBar.isHidden = true
+        self.setViewControllers(controllers, animated: false)
+        
+        // what screen to show if you're already signed in
+//        if UserService.manager.userIsSignedIn() {
+//            self.selectedIndex = 3
+//        }
+        self.moreNavigationController.navigationBar.isHidden = true
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.delegate = self
+//        UserService.manager.userListener = self
+        
+        //        let loginVC     = LoginViewController()
+        //        let createVC    = CreateAccountViewController()
+        //        let homeVC      = HomeViewController()
+        //        let studyVC     = StudyViewController()
+        ////        let decksVC     = MyDecksCollectionViewController()
+        //        let decksVC = TestCollection()
+        
+        //        loginVC.tabBarItem  = UITabBarItem(title: "login", image: nil, tag: 0)
+        //        createVC.tabBarItem = UITabBarItem(title: "create", image: nil, tag: 1)
+        //        homeVC.tabBarItem   = UITabBarItem(title: "home", image: nil, tag: 2)
+        //        decksVC.tabBarItem  = UITabBarItem(title: "decks", image: nil, tag: 3)
+        //        //        studyVC.tabBarItem  = UITabBarItem(title: "study", image: nil, tag: 3)
+        //
+        //        let homeNavVC = HiddenNavController(rootViewController: homeVC)
+        //        let studyNavVC = HiddenNavController(rootViewController: studyVC)
+        //
+        ////        let loginNavVC = UINavigationController(rootViewController: loginVC)
+        //
+        //
+        //        let controllers = [loginVC, createVC, homeVC, studyVC, decksVC]
+        //        self.tabBar.isHidden = true
+        //        self.setViewControllers(controllers, animated: false)
+        // Do any additional setup after loading the view.
+        
+//        if UserService.manager.userIsSignedIn() {
+//            selectedIndex = Page.home.rawValue
+//        }
+        
+    }
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+    
+    
+    // MARK: - Helper functions
+    
+    
+    public func animateTo(page: Page, fromViewController: UIViewController) {
+        let toIndex = page.rawValue
+        guard
+            let tabViewControllers = viewControllers,
+            let fromView = fromViewController.view,
+            let toView = tabViewControllers[toIndex].view
+            //            let fromIndex = tabViewControllers.index(of: selectedViewController!)
+            //            fromIndex != toIndex
+            else {
+                return
+        }
+        fromView.superview?.addSubview(toView)
+        
+        let screenWidth = UIScreen.main.bounds.size.width
+        let offset = (page == .login) ? -screenWidth : screenWidth
+        toView.center = CGPoint(x: fromView.center.x + offset, y: toView.center.y)
+        
+        view.isUserInteractionEnabled = false
+        
+        UIView.animate(withDuration: 0.5, delay: 0.0, usingSpringWithDamping: 1, initialSpringVelocity: 0, options: .curveEaseOut, animations: {
+            
+            toView.center = CGPoint(x: toView.center.x - offset, y: toView.center.y)
+        }) { (finished) in
+            if self.view.window == nil {
+                self.dismiss(animated: false, completion: nil)
+            }
+            
+            fromView.removeFromSuperview()
+            print(toIndex)
+            self.selectedIndex = toIndex
+            self.view.isUserInteractionEnabled = true
+        }
+    }
+    
+}
+
+//extension MainTabBarVC: UserServiceListener {
+//    func userSignedOut() {
+//        guard selectedIndex != Page.login.rawValue else { return }
+//        //        for vc in viewControllers {
+//        //            if let vc =
+//        //        }
+//        if let vc = selectedViewController as? MenuedViewController {
+//            if vc.view.window != nil {
+//                print("listener")
+//                animateTo(page: .login, fromViewController: selectedViewController!)
+//            }
+//        }
+//
+//
+//    }
+//}
+
+extension MainTabBarVC: UITabBarControllerDelegate {
+    func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        let tabViewControllers = tabBarController.viewControllers ?? []
+        guard let toIndex = tabViewControllers.index(of: viewController) else {
+            return false
+        }
+        
+        //        animateTo(page: Page(rawValue: toIndex)!)
+        animateTo(page: Page(rawValue: toIndex)!, fromViewController: selectedViewController!)
+        
+        return true
+    }
+}

--- a/wmsy/Pages/SideMenuPage/SupportFiles/MenuHelper.swift
+++ b/wmsy/Pages/SideMenuPage/SupportFiles/MenuHelper.swift
@@ -1,0 +1,73 @@
+//
+//  MenuHelper.swift
+//  wmsy
+//
+//  Created by C4Q on 3/16/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import UIKit
+
+enum Direction {
+    case up
+    case down
+    case left
+    case right
+}
+
+struct MenuHelper {
+    static let menuWidth: CGFloat = 0.85
+    static let percentThreshold: CGFloat = 0.3
+    static let snapshotNumber = 12345
+    
+    static func calculateProgress(translationInView: CGPoint, viewBounds: CGRect, direction: Direction) -> CGFloat {
+        let pointOnAxis: CGFloat
+        let axisLength: CGFloat
+        switch direction {
+        case .up, .down :
+            pointOnAxis = translationInView.y
+            axisLength = viewBounds.height
+        case .left, .right:
+            pointOnAxis = translationInView.x
+            axisLength = viewBounds.width
+        }
+
+        let movementOnAxis = pointOnAxis / axisLength
+        let positiveMovementOnAxis: Float
+        let positiveMovementOnAxisPercent: Float
+        
+        switch direction {
+        case .right, .down:
+            positiveMovementOnAxis = fmaxf(Float(movementOnAxis), 0.0)
+            positiveMovementOnAxisPercent = fminf(positiveMovementOnAxis, 1.0)
+            return CGFloat(positiveMovementOnAxisPercent)
+        case .up, .left:
+            positiveMovementOnAxis = fminf(Float(movementOnAxis), 0.0)
+            positiveMovementOnAxisPercent = fmaxf(Float(positiveMovementOnAxis), -1.0)
+            return CGFloat(-positiveMovementOnAxisPercent)
+        }
+    }
+    
+    static func mapGestureStateToInteractor(gestureState: UIGestureRecognizerState, progress: CGFloat, interactor: Interactor?, triggerSegue: () -> Void) {
+        guard let interactor = interactor else { return }
+        switch gestureState {
+        case .began:
+            interactor.hasStarted = true
+            triggerSegue()
+        case .changed:
+            interactor.shouldFinish = progress > percentThreshold
+            interactor.update(progress)
+        case .cancelled:
+            interactor.hasStarted = false
+            interactor.cancel()
+        case .ended:
+            interactor.hasStarted = false
+            interactor.shouldFinish
+                ? interactor.finish()
+                : interactor.cancel()
+        default:
+            break
+        }
+    }
+}
+

--- a/wmsy/Pages/SideMenuPage/SupportFiles/MenuViewController.swift
+++ b/wmsy/Pages/SideMenuPage/SupportFiles/MenuViewController.swift
@@ -1,0 +1,112 @@
+//
+//  MenuViewController.swift
+//  wmsy
+//
+//  Created by C4Q on 3/16/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+//import MaterialComponents.MaterialCollections
+
+private let reuseIdentifier = "Cell"
+
+//enum Page: Int {
+//    case login
+//    case create
+//    case home
+//    case decks
+//    case progress
+//    case browse
+//    case profile
+//    case inbox
+//}
+
+class MenuViewController: UIViewController {
+    @IBAction func closeMenu(sender: AnyObject) {
+        dismiss(animated: true, completion: nil)
+    }
+    
+    var closeButton = UIButton()
+    //    var tabButton = UIButton()
+    weak var fromVC: UIViewController? {
+        didSet {
+            print(0)
+        }
+    }
+    var signOutButton = UIButton()
+    
+    // the menu objects should be added to menuScreen not self.view
+    var menuScreen = UIView()
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupMenuRegion()
+        setupCloseMenuRegion()
+    }
+    
+    private func setupMenuRegion() {
+        view.addSubview(menuScreen)
+        menuScreen.backgroundColor = .red
+        menuScreen.snp.makeConstraints { (make) in
+            make.leading.top.bottom.equalTo(view)
+            make.width.equalTo(view).multipliedBy(MenuHelper.menuWidth)
+        }
+    }
+    private func setupCloseMenuRegion() {
+        let panGestureRecognizer = UIPanGestureRecognizer.init(target: self, action: #selector(handleClosingGesture(sender:)))
+        closeButton.addTarget(self, action: #selector(closeMenu(sender:)), for: .touchUpInside)
+        closeButton.addGestureRecognizer(panGestureRecognizer)
+        view.addSubview(closeButton)
+        closeButton.snp.makeConstraints { (make) in
+            make.top.bottom.trailing.equalTo(view)
+            make.width.equalTo(view).multipliedBy(1 - MenuHelper.menuWidth)
+        }
+    }
+    
+    @objc func signOut() {
+        switchTo(page: .login)
+//        var keepTryingClosure: ((Bool, Error?) -> Void)!
+//        keepTryingClosure = {(success, error) in
+//            if let error = error {
+//                print(error._userInfo?[NSLocalizedFailureReasonErrorKey] ?? "")
+//                //                UserService.manager.signOut(completion: keepTryingClosure)
+//            }
+//            if success {
+//                print("successfully signed out")
+//                self.switchTo(page: .login)
+//            }
+//        }
+        //        UserService.manager.signOut(completion: keepTryingClosure)
+    }
+    
+    // 1
+    weak var interactor: Interactor?
+    // 2
+    @objc func handleClosingGesture(sender: UIPanGestureRecognizer) {
+        // 3
+        let translation = sender.translation(in: view)
+        // 4
+        let progress = MenuHelper.calculateProgress(
+            translationInView: translation,
+            viewBounds: view.bounds,
+            direction: .left
+        )
+        // 5
+        MenuHelper.mapGestureStateToInteractor(
+            gestureState: sender.state,
+            progress: progress,
+            interactor: interactor){
+                // 6
+                self.dismiss(animated: true, completion: nil)
+        }
+    }
+    
+    private func switchTo(page: Page) {
+                (fromVC?.tabBarController as? MainTabBarVC)?.animateTo(page: page, fromViewController: self)
+    }
+    
+    
+    
+}
+

--- a/wmsy/Pages/SideMenuPage/SupportFiles/MenuedViewController.swift
+++ b/wmsy/Pages/SideMenuPage/SupportFiles/MenuedViewController.swift
@@ -1,0 +1,107 @@
+//
+//  MenuedViewController.swift
+//  wmsy
+//
+//  Created by C4Q on 3/16/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import UIKit
+//import MaterialComponents
+
+class MenuedViewController: UIViewController {
+    
+//    var viewIsVisible: Bool = true
+//    override var prefersStatusBarHidden: Bool {
+//        return !viewIsVisible
+//    }
+    let interactor = Interactor()
+//    let headerViewController = MDCFlexibleHeaderViewController()
+    
+    @IBAction func openMenu(sender: AnyObject) {
+        //        performSegueWithIdentifier("openMenu", sender: nil)
+        let menu = SideMenuVC()
+        menu.transitioningDelegate = self
+        menu.interactor = interactor
+        menu.fromVC = self
+        present(menu, animated: true, completion: nil)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+//        navigationController?.navigationBar.isHidden = true
+        view.backgroundColor = .white
+        let screenGesture = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(edgePanGesture(sender:)))
+        screenGesture.edges = .left
+        view.addGestureRecognizer(screenGesture)
+        
+        view.backgroundColor = .blue
+//        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(openMenu(sender:)))
+        
+    }
+    
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+//        viewIsVisible = true
+//        UIView.animate(withDuration: 0.5) {
+//            self.setNeedsStatusBarAppearanceUpdate()
+//        }
+    }
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+//        viewIsVisible = true
+//        UIView.animate(withDuration: 0.1) {
+//                self.setNeedsStatusBarAppearanceUpdate()
+//        }
+    }
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+//        viewIsVisible = false
+//        UIView.animate(withDuration: 0.5) {
+//            self.setNeedsStatusBarAppearanceUpdate()
+//        }
+    }
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+//        viewIsVisible = false
+//        UIView.animate(withDuration: 0.1) {
+//            self.setNeedsStatusBarAppearanceUpdate()
+//        }
+    }
+    
+    @IBAction func edgePanGesture(sender: UIScreenEdgePanGestureRecognizer) {
+        let translation = sender.translation(in: view)
+        
+        let progress = MenuHelper.calculateProgress(translationInView: translation, viewBounds: view.bounds, direction: .right)
+        
+        MenuHelper.mapGestureStateToInteractor(
+            gestureState: sender.state,
+            progress: progress,
+            interactor: interactor){
+                //                self.performSegueWithIdentifier("openMenu", sender: nil)
+                let menu = SideMenuVC()
+                menu.transitioningDelegate = self
+                menu.interactor = interactor
+                menu.fromVC = self
+                present(menu, animated: true, completion: nil)
+        }
+    }
+    
+}
+
+extension MenuedViewController: UIViewControllerTransitioningDelegate {
+    func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return PresentMenuAnimator()
+    }
+    func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return DismissMenuAnimator()
+    }
+    func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
+        return interactor.hasStarted ? interactor : nil
+    }
+    func interactionControllerForPresentation(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
+        return interactor.hasStarted ? interactor : nil
+    }
+}
+

--- a/wmsy/Pages/SideMenuPage/SupportFiles/Page.swift
+++ b/wmsy/Pages/SideMenuPage/SupportFiles/Page.swift
@@ -1,0 +1,26 @@
+//
+//  Page.swift
+//  wmsy
+//
+//  Created by C4Q on 3/19/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import Foundation
+
+enum Page: Int {
+    case login
+    case feedAndMap
+    case chatRoom
+//    case create
+//    case home
+//    case decks
+//    case progress
+//    case browse
+//    case profile
+//    case inbox
+}
+
+
+
+

--- a/wmsy/Pages/SideMenuPage/SupportFiles/PresentMenuAnimator.swift
+++ b/wmsy/Pages/SideMenuPage/SupportFiles/PresentMenuAnimator.swift
@@ -1,0 +1,50 @@
+//
+//  PresentMenuAnimator.swift
+//  wmsy
+//
+//  Created by C4Q on 3/16/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import UIKit
+
+class PresentMenuAnimator : NSObject {
+}
+
+extension PresentMenuAnimator : UIViewControllerAnimatedTransitioning {
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        return 0.6
+    }
+    
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        guard
+            let fromVC = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.from),
+            let toVC = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.to)
+            else {
+                return
+        }
+        let containerView = transitionContext.containerView
+        // more code goes here
+        containerView.insertSubview(toVC.view, belowSubview: fromVC.view)
+        
+        guard let snapshot = fromVC.view.snapshotView(afterScreenUpdates: false) else { return }
+        snapshot.tag = MenuHelper.snapshotNumber
+        snapshot.isUserInteractionEnabled = false
+        snapshot.layer.shadowOpacity = 0.7
+        containerView.insertSubview(snapshot, aboveSubview: toVC.view)
+        fromVC.view.isHidden = true
+        
+        
+        UIView.animate(
+            withDuration: transitionDuration(using: transitionContext),
+            animations: {
+                snapshot.center.x += UIScreen.main.bounds.width * MenuHelper.menuWidth
+        },
+            completion: { _ in
+                fromVC.view.isHidden = false
+                transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+        }
+        )
+    }
+}
+

--- a/wmsy/Pages/SideMenuPage/Views/MenuCollectionViewWrapper.swift
+++ b/wmsy/Pages/SideMenuPage/Views/MenuCollectionViewWrapper.swift
@@ -1,0 +1,100 @@
+//
+//  MenuCollectionViewWrapper.swift
+//  wmsy
+//
+//  Created by C4Q on 3/16/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+
+class MenuCollectionViewWrapper: UIView {
+    static let pageOneIdentifier = "ProfileView"
+    static let pageTwoIdentifier = "WhimsView"
+    
+    public lazy var menuPagesCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        cv.bounces = false
+        cv.isPagingEnabled = true
+        cv.register(MenuProfileView.self, forCellWithReuseIdentifier: MenuCollectionViewWrapper.pageOneIdentifier)
+        cv.register(MenuWhimsView.self, forCellWithReuseIdentifier: MenuCollectionViewWrapper.pageTwoIdentifier)
+        return cv
+    }()
+    private var persistentMenuFooter = UIView()
+    private var leftDot = UIView()
+    private var rightDot = UIView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    convenience init() {
+        self.init(frame: UIScreen.main.bounds)
+    }
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    private func commonInit() {
+        backgroundColor = Stylesheet.Colors.WMSYAshGrey
+        setupViews()
+        layoutStuff()
+    }
+    
+    
+    
+    
+    private func setupViews() {
+        setupMenuPagesCollectionView()
+        setupPersistentMenuFooter()
+        setupLeftDot()
+        setupRightDot()
+    }
+    private func setupMenuPagesCollectionView() {
+        addSubview(menuPagesCollectionView)
+        menuPagesCollectionView.backgroundColor = UIColor.clear
+        menuPagesCollectionView.snp.makeConstraints { (make) in
+            make.edges.equalTo(self)
+        }
+    }
+    
+    private let bottomViewHeight: CGFloat = 100
+    private func setupPersistentMenuFooter() {
+        persistentMenuFooter.isUserInteractionEnabled = false
+        addSubview(persistentMenuFooter)
+        persistentMenuFooter.snp.makeConstraints { (make) in
+            make.leading.trailing.bottom.equalTo(self)
+            make.height.equalTo(bottomViewHeight)
+        }
+    }
+    private func setupLeftDot() {
+        leftDot.clipsToBounds = true
+        leftDot.backgroundColor = Stylesheet.Colors.WMSYSeaFoamGreen
+        leftDot.layer.cornerRadius = (bottomViewHeight * 0.10) / 2
+        persistentMenuFooter.addSubview(leftDot)
+        leftDot.snp.makeConstraints { (make) in
+            make.centerY.equalTo(persistentMenuFooter)
+            make.height.width.equalTo(bottomViewHeight * 0.10)
+            make.centerX.equalTo(persistentMenuFooter).offset(-10)
+        }
+    }
+    private func setupRightDot() {
+        rightDot.clipsToBounds = true
+        rightDot.backgroundColor = Stylesheet.Colors.WMSYSeaFoamGreen
+        rightDot.layer.cornerRadius = (bottomViewHeight * 0.10) / 2
+        persistentMenuFooter.addSubview(rightDot)
+        rightDot.snp.makeConstraints { (make) in
+            make.centerY.equalTo(persistentMenuFooter)
+            make.height.width.equalTo(bottomViewHeight * 0.10)
+            make.centerX.equalTo(persistentMenuFooter).offset(10)
+        }
+    }
+    // MARK: - helper functions
+
+    public func layoutStuff() {
+    }
+}

--- a/wmsy/Pages/SideMenuPage/Views/MenuProfileView.swift
+++ b/wmsy/Pages/SideMenuPage/Views/MenuProfileView.swift
@@ -1,0 +1,111 @@
+//
+//  MenuProfileView.swift
+//  wmsy
+//
+//  Created by C4Q on 3/16/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+class MenuProfileView: UICollectionViewCell {
+//    public var header = UIView()
+    public var badgeView = UIView()
+    public var profileImageView = UIImageView(image: #imageLiteral(resourceName: "wmsyCategoryIcon"))
+    public var nameLabel = UILabel()
+    public var ageLabel = UILabel()
+    public var bioLabel = UILabel()
+    public var signOutButton = UIButton()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    convenience init() {
+        self.init(frame: UIScreen.main.bounds)
+    }
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    private func commonInit() {
+        setupViews()
+        placeholderTesting()
+    }
+    
+    private func setupViews() {
+        setupBadgeView()
+        setupProfileImageView()
+        setupNameLabel()
+        setupAgeLabel()
+        setupBioLabel()
+        setupSignOutButton()
+    }
+    
+    private func setupBadgeView() {
+        contentView.addSubview(badgeView)
+        badgeView.snp.makeConstraints { (make) in
+            make.top.trailing.equalTo(contentView).inset(16)
+            make.height.equalTo(50)
+            make.width.equalTo(150)
+        }
+    }
+    private func setupProfileImageView() {
+        contentView.addSubview(profileImageView)
+        profileImageView.snp.makeConstraints { (make) in
+            make.centerX.equalTo(contentView)
+            make.width.height.equalTo(contentView.snp.width).multipliedBy(0.6)
+            make.top.equalTo(badgeView.snp.bottom).offset(40)
+        }
+    }
+    private func setupNameLabel() {
+        nameLabel.textAlignment = .center
+        contentView.addSubview(nameLabel)
+        nameLabel.snp.makeConstraints { (make) in
+            make.centerX.width.equalTo(contentView)
+            make.top.equalTo(profileImageView.snp.bottom).offset(8)
+        }
+    }
+    private func setupAgeLabel() {
+        ageLabel.textAlignment = .center
+        contentView.addSubview(ageLabel)
+        ageLabel.snp.makeConstraints { (make) in
+            make.centerX.width.equalTo(contentView)
+            make.top.equalTo(nameLabel.snp.bottom).offset(8)
+        }
+    }
+    private func setupBioLabel() {
+        contentView.addSubview(bioLabel)
+        bioLabel.snp.makeConstraints { (make) in
+            make.centerX.equalTo(contentView.snp.centerX)
+            make.width.equalTo(contentView).multipliedBy(0.75)
+            make.top.equalTo(ageLabel.snp.bottom).offset(20)
+        }
+    }
+    private func setupSignOutButton() {
+        contentView.addSubview(signOutButton)
+        signOutButton.snp.makeConstraints { (make) in
+            make.leading.bottom.equalTo(contentView).inset(16)
+        }
+    }
+    private func placeholderTesting() {
+        let bgColor = Stylesheet.Colors.WMSYOuterSpace
+        let fontColor = Stylesheet.Colors.WMSYIsabelline
+        badgeView.backgroundColor = bgColor
+        profileImageView.backgroundColor = bgColor
+        ageLabel.backgroundColor = bgColor
+        ageLabel.textColor = fontColor
+        nameLabel.backgroundColor = bgColor
+        nameLabel.textColor = fontColor
+        bioLabel.backgroundColor = bgColor
+        bioLabel.textColor = fontColor
+        signOutButton.backgroundColor = bgColor
+        signOutButton.setTitleColor(fontColor, for: .normal)
+        
+        nameLabel.text = "HotRod"
+        ageLabel.text = "4206969 years old"
+        bioLabel.text = "I'm Rod and I like to party."
+        signOutButton.setTitle("Signout", for: .normal)
+    }
+}

--- a/wmsy/Pages/SideMenuPage/Views/MenuWhimsCell.swift
+++ b/wmsy/Pages/SideMenuPage/Views/MenuWhimsCell.swift
@@ -1,0 +1,76 @@
+//
+//  MenuWhimsCell.swift
+//  wmsy
+//
+//  Created by C4Q on 3/18/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+class MenuWhimsCell: UITableViewCell {
+    
+    private var whimTitle = UILabel()
+    private var notificationBadge = UIView()
+    
+    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        commonInit()
+    }
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        commonInit()
+    }
+    private func commonInit() {
+//        backgroundColor = Stylesheet.Colors.WMSYIsabelline
+        backgroundColor = .clear
+        setupViews()
+        placeholderTesting()
+    }
+    private func setupViews() {
+        setupWhimTitle()
+        setupNotificationBadge()
+    }
+    
+    private func setupWhimTitle() {
+        whimTitle.textColor = Stylesheet.Colors.WMSYMummysTomb
+        contentView.addSubview(whimTitle)
+        whimTitle.numberOfLines = 2
+        whimTitle.snp.makeConstraints { (make) in
+            make.edges.equalTo(contentView.layoutMarginsGuide)
+        }
+    }
+    private func setupNotificationBadge() {
+        contentView.addSubview(notificationBadge)
+        notificationBadge.layer.cornerRadius = 15 / 2
+        notificationBadge.clipsToBounds = true
+        notificationBadge.snp.makeConstraints { (make) in
+            make.height.width.equalTo(15)
+            make.centerX.equalTo(whimTitle.snp.trailing)
+            make.centerY.equalTo(whimTitle.snp.top)
+        }
+    }
+    private func placeholderTesting() {
+        whimTitle.text = "Testing putting some very long message in a chat title when looking at it through a menu. This text is set in MenuWhimsCell.swift"
+        notificationBadge.backgroundColor = .red
+        selectionStyle = .none
+        
+    }
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+        
+        // Configure the view for the selected state
+        UIView.animate(withDuration: 0.4, animations: {
+            if selected {
+                self.backgroundColor = Stylesheet.Colors.WMSYMummysTomb
+            } else {
+                self.backgroundColor = .clear
+            }
+        })
+    }
+}

--- a/wmsy/Pages/SideMenuPage/Views/MenuWhimsHeader.swift
+++ b/wmsy/Pages/SideMenuPage/Views/MenuWhimsHeader.swift
@@ -1,0 +1,52 @@
+//
+//  MenuWhimsHeader.swift
+//  wmsy
+//
+//  Created by C4Q on 3/17/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+class MenuWhimsHeader: UITableViewHeaderFooterView {
+    public let titleLabel = UILabel()
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        commonInit()
+    }
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    private func commonInit() {
+        contentView.backgroundColor = Stylesheet.Colors.WMSYOuterSpace
+        setupViews()
+        placeholderTesting()
+    }
+    
+    private func setupViews() {
+        setupTitleLabel()
+    }
+    private func setupTitleLabel() {
+        contentView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { (make) in
+            make.leading.trailing.top.bottom.equalTo(contentView.layoutMarginsGuide)
+        }
+    }
+    private func placeholderTesting() {
+        titleLabel.font = UIFont.systemFont(ofSize: 25, weight: .heavy)
+        titleLabel.textColor = Stylesheet.Colors.WMSYSeaFoamGreen
+        titleLabel.text = "Host Chats"
+    }
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/wmsy/Pages/SideMenuPage/Views/MenuWhimsView.swift
+++ b/wmsy/Pages/SideMenuPage/Views/MenuWhimsView.swift
@@ -1,0 +1,53 @@
+//
+//  MenuWhimsView.swift
+//  wmsy
+//
+//  Created by C4Q on 3/16/18.
+//  Copyright © 2018 C4Q. All rights reserved.
+//
+
+import UIKit
+
+class MenuWhimsView: UICollectionViewCell {
+    
+    static let headerIdentifier = "WhimsHeader"
+    static let cellIdentifier = "WhimsCell"
+    public var whimsTableView = UITableView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    convenience init() {
+        self.init(frame: UIScreen.main.bounds)
+    }
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    private func commonInit() {
+        backgroundColor = .clear
+        setupViews()
+    }
+    
+    private func setupViews() {
+        setupWhimsTableView()
+    }
+    private func setupWhimsTableView() {
+        whimsTableView.separatorStyle = .none
+        whimsTableView.contentInsetAdjustmentBehavior = .never
+        whimsTableView.backgroundColor = .clear
+        whimsTableView.register(MenuWhimsHeader.self, forHeaderFooterViewReuseIdentifier: MenuWhimsView.headerIdentifier)
+        whimsTableView.register(MenuWhimsCell.self, forCellReuseIdentifier: MenuWhimsView.cellIdentifier)
+        whimsTableView.sectionHeaderHeight = UITableViewAutomaticDimension
+        whimsTableView.rowHeight = UITableViewAutomaticDimension
+        whimsTableView.estimatedSectionHeaderHeight = 100
+        whimsTableView.estimatedRowHeight = 100
+        whimsTableView.bounces = false
+        contentView.addSubview(whimsTableView)
+        whimsTableView.snp.makeConstraints { (make) in
+            make.edges.equalTo(contentView)
+        }
+    }
+    
+}


### PR DESCRIPTION
There is now a menu that handles switching between pages

if you want to avoid having to sign in every time FOR TESTING then change the selected index of the MainTabBarVC (wmsy > Pages > SideMenuPage > SupportFiles > MainTabBarVC.swift)

if you want to handle signing out, add code to the MenuViewController inside the signOut() method
(wmsy > Pages > SideMenuPage > SupportFiles > MenuViewController.swift)