### PR TITLE
Persist Nav Bar When Return to FeedVC

### DIFF
--- a/wmsy/Pages/FeedMapPage/FeedMapVC.swift
+++ b/wmsy/Pages/FeedMapPage/FeedMapVC.swift
@@ -102,6 +102,10 @@ class FeedMapVC: MenuedViewController {
         navigationController?.navigationBar.isHidden = true
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.navigationBar.isHidden = false
+    }
+    
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         print("removing live feed updates")


### PR DESCRIPTION
Nav Bar is no longer hidden when returning to feed vc from side menu